### PR TITLE
Allow `localStorage.setItem` to fail

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -130,7 +130,11 @@ async function run(input: string, filter: string, setOut: Function) {
     }
   }
 
-  localStorage.setItem(storageKey, JSON.stringify({ input, filter }))
+  try {
+    localStorage.setItem(storageKey, JSON.stringify({ input, filter }))
+  } catch (err) {
+    console.warn('failed to set local storage', err)
+  }
   setOut(output.join('\n'))
 }
 


### PR DESCRIPTION
Signed-off-by: Thiago Padilha <thiago@calyptia.com>